### PR TITLE
add support gnome-shell version 3.21.91 (current in debian testing)

### DIFF
--- a/impatience/metadata.json
+++ b/impatience/metadata.json
@@ -3,5 +3,5 @@
   "name": "Impatience",
   "description": "Speed up the gnome-shell animation speed",
   "url": "http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml",
-  "shell-version": [ "3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20" ]
+  "shell-version": [ "3.4", "3.6", "3.8", "3.10", "3.12", "3.14", "3.16", "3.18", "3.20", "3.21.91" ]
 }


### PR DESCRIPTION
the Gnome Shell version used in Debian testing branch has been added
