### PR TITLE
Use gtk4.0 JS API for Gnome 40

### DIFF
--- a/impatience/metadata.json
+++ b/impatience/metadata.json
@@ -3,5 +3,5 @@
   "name": "Impatience",
   "description": "Speed up the gnome-shell animation speed",
   "url": "http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml",
-  "shell-version": [ "3.34" , "3.36" ]
+  "shell-version": [ "40" ]
 }

--- a/impatience/prefs.js
+++ b/impatience/prefs.js
@@ -35,15 +35,19 @@ function buildPrefsWidget() {
 			orientation: Gtk.Orientation.HORIZONTAL,
 			digits:2,
 			adjustment: adjustment,
+			hexpand: true,
 			value_pos: Gtk.PositionType.RIGHT
 		});
 
 		hbox.append(label);
-		hbox.pack_end(scale, true, true, 0);
+		hbox.append(scale);
 		frame.append(hbox);
 
 		var pref = config.SPEED;
 		scale.set_value(pref.get());
+		[0.25, 0.5, 1.0, 2.0].forEach(
+			mark => scale.add_mark(mark, Gtk.PositionType.TOP, "<small>" + mark + "</small>")
+		);
 		scale.connect('value-changed', function(sw) {
 			var oldval = pref.get();
 			var newval = sw.get_value();
@@ -53,6 +57,6 @@ function buildPrefsWidget() {
 		});
 	})();
 
-	frame.show_all();
+	frame.show();
 	return frame;
 }

--- a/impatience/prefs.js
+++ b/impatience/prefs.js
@@ -31,7 +31,8 @@ function buildPrefsWidget() {
 			upper: 2,
 			step_increment: 0.05
 		});
-		let scale = new Gtk.HScale({
+		let scale = new Gtk.Scale({
+			orientation: Gtk.Orientation.HORIZONTAL,
 			digits:2,
 			adjustment: adjustment,
 			value_pos: Gtk.PositionType.RIGHT

--- a/impatience/prefs.js
+++ b/impatience/prefs.js
@@ -10,7 +10,10 @@ function buildPrefsWidget() {
 	let config = new Settings.Prefs();
 	let frame = new Gtk.Box({
 		orientation: Gtk.Orientation.VERTICAL,
-		border_width: 10
+		'margin-top': 20,
+		'margin-bottom': 20,
+		'margin-start': 20,
+		'margin-end': 20
 	});
 
 	(function() {

--- a/impatience/prefs.js
+++ b/impatience/prefs.js
@@ -38,9 +38,9 @@ function buildPrefsWidget() {
 			value_pos: Gtk.PositionType.RIGHT
 		});
 
-		hbox.add(label);
+		hbox.append(label);
 		hbox.pack_end(scale, true, true, 0);
-		frame.add(hbox);
+		frame.append(hbox);
 
 		var pref = config.SPEED;
 		scale.set_value(pref.get());


### PR DESCRIPTION
This PR replaces API calls that are deprecated in Gtk4.0 with their current counterparts, which should allow the preference box to show up again, fixing #23.

![2021-04-07 00-00-48 的屏幕截图](https://user-images.githubusercontent.com/3353318/113812807-54b25900-9734-11eb-8a17-f05d620233aa.png)

I tried to show the current value right next to the slider, but the spacing between the slider and the value does not seem to work., so it's replaced with a few ticks so that people know approximately what value they choose.

Note that now `prefs.js` contains Gtk 4.0 only APIs, this is unlikely to work anything before 40.