### PR TITLE
gnome 44 support

### DIFF
--- a/impatience/metadata.json
+++ b/impatience/metadata.json
@@ -3,5 +3,5 @@
   "name": "Impatience",
   "description": "Speed up the gnome-shell animation speed",
   "url": "http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml",
-  "shell-version": [ "40", "41", "42", "43" ]
+  "shell-version": [ "40", "41", "42", "43", "44" ]
 }


### PR DESCRIPTION
I recently updated to gnome 44, and the extension wouldn't load without this change.  After, it seems to be working as expected.