### PR TITLE
Add gnome-shell 46 support

### DIFF
--- a/impatience/metadata.json
+++ b/impatience/metadata.json
@@ -3,6 +3,9 @@
   "name": "Impatience",
   "description": "Speed up the gnome-shell animation speed",
   "url": "http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml",
-  "shell-version": [ "45" ],
+  "shell-version": [
+    "45",
+    "46"
+  ],
   "settings-schema": "org.gnome.shell.extensions.net.gfxmonk.impatience"
 }


### PR DESCRIPTION
Code seems to work fine with gnome-shell 46 as I'm running now on Arch (with version check disabled). So should be able to simply declare support for 46.