### PR TITLE
Add readme note about env var GNOME_SHELL_SLOWDOWN_FACTOR

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 <img src="http://gfxmonk.net/dist/status/project/gnome-shell-impatience.png">
 
 Speed up builtin gnome-shell animations.
+
+## Setting speed factor permanently without extension
+Add environment variable e.g. to `/etc/environment`
+```
+GNOME_SHELL_SLOWDOWN_FACTOR=0.4
+```


### PR DESCRIPTION
I recently found the [slowdown factor can be set by env var](https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/7513#note_2061681) which allows setting it permanently without extension.

This could be useful in the readme as an alternative. Or feel free to close this if you disagree.  