### PR TITLE
Mark compatible with GNOME Shell 47

### DIFF
--- a/impatience/metadata.json
+++ b/impatience/metadata.json
@@ -5,7 +5,8 @@
   "url": "http://gfxmonk.net/dist/0install/gnome-shell-impatience.xml",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47"
   ],
   "settings-schema": "org.gnome.shell.extensions.net.gfxmonk.impatience"
 }


### PR DESCRIPTION
GNOME 47 is scheduled for release on Wednesday.

I did a very simple smoketest with this change on Debian with gnome-shell 47.rc . I didn't notice a speed up in animations but the animations I saw were quite fast already.

See also https://gjs.guide/extensions/upgrading/gnome-shell-47.html