### PR TITLE
Mark compatible with GNOME Shell 48

### DIFF
--- a/impatience/metadata.json
+++ b/impatience/metadata.json
@@ -6,7 +6,8 @@
   "shell-version": [
     "45",
     "46",
-    "47"
+    "47",
+    "48"
   ],
   "settings-schema": "org.gnome.shell.extensions.net.gfxmonk.impatience"
 }


### PR DESCRIPTION
I did a quick test of this extension with GNOME Shell 48 Beta on Ubuntu 25.04 and things appeared to work ok.

See https://gjs.guide/extensions/upgrading/gnome-shell-48.html